### PR TITLE
Added intitial schema for API documentation

### DIFF
--- a/docs/02-technical/03-api/schema.yaml
+++ b/docs/02-technical/03-api/schema.yaml
@@ -53,7 +53,7 @@ paths:
                             email:
                                 type: string
                             name:
-                                typpe: string
+                                type: string
                     example:
                         name: Ingolf Neiße
                         email: ingolf@neis.se
@@ -80,6 +80,84 @@ paths:
                             type: array
                             items:
                                 $ref: '#/components/schemas/Activity'
+    post:
+        summary: Create an activity as manual record (limits may apply)
+        operationId: recordActivity
+        tags:
+            - Activity
+        requestBody:
+            content:
+                application/json:
+                    schema:
+                        type: object
+                        properties:
+                            type:
+                                type: integer
+                            begin:
+                                type: string
+                                format: date-time
+                            end:
+                                type: string
+                                format: date-time
+                            value:
+                                type: number
+                            metric:
+                                type: integer
+                            points:
+                                type: integer
+        responses:
+            '201':
+                description: The activity was created successfully
+                content:
+                    'application/json':
+                        schema:
+                            $ref: '#/components/schemas/Activity'
+            '400':
+                description: Invalid properties / activity type not supported
+            '401':
+                description: User is not authenticated
+ '/activities/{id}':
+    get:
+        summary: Returns a single activity
+        operationId: getActivity
+        tags:
+            - Activity
+        parameters:
+            - in: path
+              name: id
+              schema:
+                type: string
+              required: true
+        responses:
+            '200':
+                description: Activity
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Activity'
+            '404':
+                description: Activity not found
+            '401':
+                description: User is not authenticated
+    delete:
+        summary: Delete an activity
+        operationId: deleteActivity
+        tags:
+            - Activity
+        parameters:
+            - in: path
+              name: id
+              schema:
+                type: string
+              required: true
+        responses:
+            '204':
+                description: Activity deleted successfully
+            '403':
+                description: Not allowed to delete activity
+            '401':
+                description: User not authenticated
+                            
 components:
   schemas:
     User:
@@ -105,8 +183,10 @@ components:
           type: integer
         begin:
           type: string
+          format: date-time
         end:
           type: string
+          format: date-time
         value:
           type: number
         metric:

--- a/docs/02-technical/03-api/schema.yaml
+++ b/docs/02-technical/03-api/schema.yaml
@@ -1,0 +1,138 @@
+openapi: 3.0.3
+info:
+  title: DuoGradus - API Spezifikation
+  description: |-
+    👟 DuoGradus
+
+    “DuoGradus” ist eine innovative Anwendung, die dir hilft, deine Fitness-Ziele zu erreichen. Dazu bieten wir dir ein innovatives Konzept, welches auf Gamification und Regelmäßigkeit setzt, sodass du dein Ziel auch langfristig erreichen kannst.
+    
+    Mithilfe von vielen spannenden Challenges ermutigen wir dich Schritte zu sammeln, Fahrrad zu fahren oder im Fitness-Studio zu trainieren. Manchmal geben wir dir auch zusätzliche Herausforderungen (z.B. Schritte im Regen), die dann mit Abzeichen und anderen Erfolgen belohnt werden.
+    
+    Damit dir nicht langweilig wird, kannst du dich zusätzlich mit deinen Freunden, aber auch in der globalen Rangliste vergleichen, sodass du immer die Motivation hast, Punkte zu sammeln.
+  version: 1.0.0
+externalDocs:
+  description: Projekt-Repository
+  url: https://github.com/SE-TINF22B2/G5-DuoGradus
+tags:
+  - name: User
+    description: Enpoints related to the user, his account and other personal configurations
+  - name: Activity
+    description: Activities of the current user
+  - name: Achievements
+  - name: Datasources
+  - name: Leaderboard
+  - name: Shop
+  - name: Order
+paths:
+ '/users/me':
+    get:
+      summary: Displays the current users settings
+      operationId: getUser
+      tags:
+        - User
+      responses:
+        '200':
+          description: User object for the current user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+            description: User not authenticated
+    patch:
+        summary: Changes a user session
+        operationId: patchUser
+        tags:
+            - User
+        requestBody:
+            content:
+                application/json:
+                    schema:
+                        type: object
+                        parameters:
+                            email:
+                                type: string
+                            name:
+                                typpe: string
+                    example:
+                        name: Ingolf Neiße
+                        email: ingolf@neis.se
+
+        responses:
+            '204':
+                description: User changed successfully
+            '400':
+                description: Invalid content
+            '403':
+                description: Not allowed to change attribute
+ '/activies':
+    get:
+        summary: Get a list of activities of the current user
+        operationId: listActivities
+        tags:
+            - Activity
+        responses:
+            '200':
+                description: List of activities
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                $ref: '#/components/schemas/Activity'
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+        verified:
+          type: boolean
+    Activity:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: integer
+        begin:
+          type: string
+        end:
+          type: string
+        value:
+          type: number
+        metric:
+          type: integer
+        datasource:
+          type: string
+          format: uuid
+        points:
+          type: integer
+    Achievement:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: integer
+        achieved:
+          type: boolean
+    Datasource:
+      type: object
+    Leaderboard:
+      type: object
+    ShopItem:
+      type: object
+    OrderItem:
+      type: object
+    Order:
+      type: object

--- a/docs/02-technical/03-api/schema.yaml
+++ b/docs/02-technical/03-api/schema.yaml
@@ -346,19 +346,17 @@ components:
     Order:
       type: object
     Leaderboard:
-      schema:
-        type: object
-        properties:
-          position:
-            type: integer
-          color:
-            type: integer
-          displayname:
-            type: string
-          points:
-            type: integer
+      type: object
+      properties:
+        position:
+          type: integer
+        color:
+          type: integer
+        displayname:
+          type: string
+        points:
+          type: integer
     PrivateLeaderboard:
-        schema:
           type: object
           properties:
             id:

--- a/docs/02-technical/03-api/schema.yaml
+++ b/docs/02-technical/03-api/schema.yaml
@@ -157,6 +157,137 @@ paths:
                 description: Not allowed to delete activity
             '401':
                 description: User not authenticated
+ '/achievements':
+    get:
+      summary: Get a list of all achievements for the current user
+      operationId: getAchievements
+      tags:
+        - Achievements
+      responses:
+        '200':
+          description: List of Achievements
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Achievement'
+ '/datasources':
+    get:
+      summary: Get a list of all connected data sources
+      operationId: getDatasources
+      tags:
+        - Datasources
+      responses:
+        '200':
+          description: List of connected data sources of the current user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Datasource'
+ '/leaderboard':
+    get:
+      summary: Get the general leaderboard
+      operationId: getGeneralLeaderb
+      tags:
+        - Leaderboard
+      responses:
+        '200':
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Leaderboard'
+ '/leaderboards':
+    get:
+      summary: Get a list of private leaderboards the user can access
+      operationId: getLeaderboards
+      tags:
+        - Leaderboard
+      responses:
+        '200':
+          description: Return a single leaderboard
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Leaderboard'
+    post:
+      summary: Create a private leaderborad
+      operationId: createLeaderboard
+      tags:
+        - Leaderboard
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                public:
+                  type: boolean
+      responses:
+        '201':
+          description: Leaderboard created
+ '/leaderboards/join':
+    post:
+      summary: Join a private / public leaderboard
+      operationId: joinLeaderboard
+      tags:
+        - Leaderboard
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+      responses:
+        '204':
+          description: Joined leaderboard successfully
+        '404':
+          description: Leaderboard does not exists
+        '401':
+          description: User not authorized
+ '/leaderboards/{id}':
+    get:
+      summary: Get a list of private leaderboards the user can access
+      operationId: getPrivateLeaderboard
+      tags:
+        - Leaderboard
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Return a single leaderboard
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Leaderboard'
+    delete:
+      summary: Leave a leaderboard. If the user is the only user left, delete the leaderboard
+      operationId: leaveOrDeleteLeaderboard
+      tags:
+        - Leaderboard
+      parameters:
+        - in: path
+          required: true
+          schema:
+            type: string
+          name: id
+      responses:
+        '204':
+          description: Left the leaderboard / deleted the leaderboard
+        '404':
+          description: Leaderboard not found / user not member
+        '401':
+          description: Unauthorized
+          
                             
 components:
   schemas:
@@ -208,11 +339,33 @@ components:
           type: boolean
     Datasource:
       type: object
-    Leaderboard:
-      type: object
     ShopItem:
       type: object
     OrderItem:
       type: object
     Order:
       type: object
+    Leaderboard:
+      schema:
+        type: object
+        properties:
+          position:
+            type: integer
+          color:
+            type: integer
+          displayname:
+            type: string
+          points:
+            type: integer
+    PrivateLeaderboard:
+        schema:
+          type: object
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+            creator:
+              type: string
+            public:
+              type: boolean


### PR DESCRIPTION
Um die Diskussion über unser API-Schema unterstützen habe ich eine kleines Schema erstellt, welches ungefähr zeigen soll, wie eine REST-Dokumentation in unserem Anwendungsfall aussehen würde. Dieses Schema ist aktuell noch Work-in-Progress, falls wir uns pro REST-API entscheiden, werde ich dieses unter Mithilfe von @OG-NI ausbauen.

Das API-Schema kann hier angezeigt werden: https://editor-next.swagger.io/
Dazu einfach den Inhalt der YAML kopieren und dort einfügen