### PR TITLE
Authentication & Initial "/user/me" implementation

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -56,4 +56,4 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Prisma
-prisma/database.*
+prisma/.database.*

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -30,10 +30,6 @@ lerna-debug.log*
 
 # IDE - VSCode
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 
 # dotenv environment variable files
 .env
@@ -56,4 +52,4 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Prisma
-prisma/.database.*
+*.sqlite

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,10 +11,13 @@
       "dependencies": {
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
+        "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.0.0",
         "@prisma/client": "^5.11.0",
         "@types/bcrypt": "^5.0.2",
         "bcrypt": "^5.1.1",
+        "passport": "^0.7.0",
+        "passport-http": "^0.3.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1"
       },
@@ -1893,6 +1896,15 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/passport": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-10.0.3.tgz",
+      "integrity": "sha512-znJ9Y4S8ZDVY+j4doWAJ8EuuVO7SkQN3yOBmzxbGaXbvcSwFDAdGJ+OMCg52NdzIO4tQoN4pYKx8W6M0ArfFRQ==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "passport": "^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0"
       }
     },
     "node_modules/@nestjs/platform-express": {
@@ -7070,6 +7082,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-http": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
+      "integrity": "sha512-OwK9DkqGVlJfO8oD0Bz1VDIo+ijD3c1ZbGGozIZw+joIP0U60pXY7goB+8wiDWtNqHpkTaQiJ9Ux1jE3Ykmpuw==",
+      "dependencies": {
+        "passport-strategy": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7140,6 +7188,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "verify": "npm run build && npm run check && npm run test:cov && npm run test:e2e",
     "build": "nest build",
     "start": "nest start",
-    "start:dev": "nest start --watch",
+    "start:dev": "npm run db:reset && nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,10 +27,13 @@
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "^5.11.0",
     "@types/bcrypt": "^5.0.2",
     "bcrypt": "^5.1.1",
+    "passport": "^0.7.0",
+    "passport-http": "^0.3.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
   },
@@ -88,6 +91,6 @@
     ]
   },
   "prisma": {
-      "seed": "ts-node src/db/prisma.seed.ts"
+    "seed": "ts-node src/db/prisma.seed.ts"
   }
 }

--- a/backend/src/api/user/user.controller.spec.ts
+++ b/backend/src/api/user/user.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/api/user/user.controller.spec.ts
+++ b/backend/src/api/user/user.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
+import { User } from '@prisma/client';
 
 describe('UserController', () => {
   let controller: UserController;
@@ -14,5 +15,24 @@ describe('UserController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('Should return a SanatizedUser object in a gest request', () => {
+    const user : User = {
+      id: '1',
+      displayName: 'Max Mustermann',
+      email: 'max@mustermann.de',
+      password: '1234',
+      verified: true,
+      enabled: true,
+    }
+
+    const req = {
+      user
+    };
+
+    const response = await controller.me(req);
+
+    expect(response?.password).toBeUndefined();
   });
 });

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Request, UseGuards } from '@nestjs/common';
+import { AutoGuard } from 'src/auth/auto.guard';
+
+@Controller('user')
+export class UserController {
+
+    /**
+     * /user/me
+     * 
+     * Returns information about the current User
+     * 
+     * @param req 
+     * @returns 
+     */
+    @Get("/me")
+    @UseGuards(AutoGuard)
+    async me(@Request() req) {
+        return req.user;
+    }
+
+}

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -6,7 +6,6 @@ type SanatizedUser = Omit<User, 'password'>;
 
 @Controller('user')
 export class UserController {
-
   _sanatizeUser(user: User): SanatizedUser {
     const sanatizedUser: SanatizedUser & { password?: string } = user;
 

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -1,21 +1,30 @@
 import { Controller, Get, Request, UseGuards } from '@nestjs/common';
+import { User } from '@prisma/client';
 import { AutoGuard } from 'src/auth/auto.guard';
+
+type SanatizedUser = Omit<User, 'password'>;
 
 @Controller('user')
 export class UserController {
 
-    /**
-     * /user/me
-     * 
-     * Returns information about the current User
-     * 
-     * @param req 
-     * @returns 
-     */
-    @Get("/me")
-    @UseGuards(AutoGuard)
-    async me(@Request() req) {
-        return req.user;
-    }
+  _sanatizeUser(user: User): SanatizedUser {
+    const sanatizedUser: SanatizedUser & { password?: string } = user;
 
+    delete sanatizedUser.password;
+    return sanatizedUser;
+  }
+
+  /**
+   * /user/me
+   *
+   * Returns information about the current User
+   *
+   * @param req
+   * @returns
+   */
+  @Get('/me')
+  @UseGuards(AutoGuard)
+  async me(@Request() req) {
+    return this._sanatizeUser(req.user);
+  }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthModule } from './auth/auth.module';
+import { PrismaModule } from './db/prisma.module';
+import { UserController } from './api/user/user.controller';
 
 @Module({
-  imports: [],
-  controllers: [AppController],
+  imports: [AuthModule],
+  controllers: [AppController, UserController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { UserRepository } from 'src/db/repositories/user.repository';
+import { PassportModule } from '@nestjs/passport';
+import { HTTPStrategy } from './strategies/http.strategy';
+import { AutoGuard } from './auto.guard';
+import { PrismaModule } from 'src/db/prisma.module';
+
+@Module({
+  imports: [PrismaModule, PassportModule],
+  providers: [AuthService, HTTPStrategy, AutoGuard]
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
-import { UserRepository } from 'src/db/repositories/user.repository';
 import { PassportModule } from '@nestjs/passport';
 import { HTTPStrategy } from './strategies/http.strategy';
 import { AutoGuard } from './auto.guard';
@@ -8,6 +7,6 @@ import { PrismaModule } from 'src/db/prisma.module';
 
 @Module({
   imports: [PrismaModule, PassportModule],
-  providers: [AuthService, HTTPStrategy, AutoGuard]
+  providers: [AuthService, HTTPStrategy, AutoGuard],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+import { UserRepository } from 'src/db/repositories/user.repository';
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended';
+import { hashSync } from 'bcrypt';
+import { PrismaClient } from '@prisma/client';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let userRepository: DeepMockProxy<UserRepository>;
+
+  const exampleUser = {
+    id: '0',
+    email: 'max@example.org',
+    displayName: 'Max Mustermann',
+    password: hashSync('1234', 1),
+    enabled: true,
+    verified: false,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuthService, UserRepository, PrismaClient],
+    })
+      .overrideProvider(UserRepository)
+      .useValue(mockDeep<UserRepository>())
+    .compile();
+
+    service = module.get<AuthService>(AuthService);
+    userRepository = await module.resolve(UserRepository);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should return a user when a valid email and password is supplied', async () => {
+    userRepository.findByEmail.mockResolvedValue(exampleUser);
+
+    expect(await service.validateUserPassword("max@example.org", "1234")).toBeDefined();
+  })
+
+});

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { User } from '@prisma/client';
+import { compare } from 'bcrypt';
+import { UserRepository } from 'src/db/repositories/user.repository';
+
+@Injectable()
+export class AuthService {
+
+    constructor(
+        private userRepository: UserRepository
+    ) {}
+
+    /**
+     * Valides a user and a supplied password. This will return a user if both the username
+     * and the email is valid. If not, this will return null.
+     * 
+     * @param username 
+     * @param password 
+     * @returns 
+     */
+    async validateUserPassword(username: string, password: string): Promise<User | null> {
+        const user = await this.userRepository.findByEmail(username);
+
+        if (user && await compare(password, user.password)) {
+            return user;
+        }
+        
+        return null;
+    }
+
+}

--- a/backend/src/auth/auto.guard.ts
+++ b/backend/src/auth/auto.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+@Injectable()
+export class AutoGuard extends AuthGuard("basic") {}

--- a/backend/src/auth/strategies/http.strategy.ts
+++ b/backend/src/auth/strategies/http.strategy.ts
@@ -1,0 +1,33 @@
+import { PassportStrategy } from "@nestjs/passport";
+import { AuthService } from "../auth.service";
+import { User } from "@prisma/client";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { BasicStrategy } from "passport-http";
+
+@Injectable()
+export class HTTPStrategy extends PassportStrategy(BasicStrategy) {
+
+    constructor(private authService: AuthService) {
+        super();
+    }
+
+    /**
+     * Validates username and password via the Authentication Service
+     * 
+     * @param username 
+     * @param password 
+     * @returns 
+     */
+    async validate(username: string, password: string): Promise<User | null> {
+        console.log("Login attempt", username, password);
+
+        const user = await this.authService.validateUserPassword(username, password);
+
+        if (!user) {
+            throw new UnauthorizedException();
+        }
+
+        return user;
+    }
+
+}

--- a/backend/src/auth/strategies/http.strategy.ts
+++ b/backend/src/auth/strategies/http.strategy.ts
@@ -1,33 +1,32 @@
-import { PassportStrategy } from "@nestjs/passport";
-import { AuthService } from "../auth.service";
-import { User } from "@prisma/client";
-import { Injectable, UnauthorizedException } from "@nestjs/common";
-import { BasicStrategy } from "passport-http";
+import { PassportStrategy } from '@nestjs/passport';
+import { AuthService } from '../auth.service';
+import { User } from '@prisma/client';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { BasicStrategy } from 'passport-http';
 
 @Injectable()
 export class HTTPStrategy extends PassportStrategy(BasicStrategy) {
+  constructor(private authService: AuthService) {
+    super();
+  }
 
-    constructor(private authService: AuthService) {
-        super();
+  /**
+   * Validates username and password via the Authentication Service
+   *
+   * @param username
+   * @param password
+   * @returns
+   */
+  async validate(username: string, password: string): Promise<User | null> {
+    const user = await this.authService.validateUserPassword(
+      username,
+      password,
+    );
+
+    if (!user) {
+      throw new UnauthorizedException();
     }
 
-    /**
-     * Validates username and password via the Authentication Service
-     * 
-     * @param username 
-     * @param password 
-     * @returns 
-     */
-    async validate(username: string, password: string): Promise<User | null> {
-        console.log("Login attempt", username, password);
-
-        const user = await this.authService.validateUserPassword(username, password);
-
-        if (!user) {
-            throw new UnauthorizedException();
-        }
-
-        return user;
-    }
-
+    return user;
+  }
 }

--- a/backend/src/db/prisma.module.ts
+++ b/backend/src/db/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { UserRepository } from "./repositories/user.repository";
+import { PrismaService } from "./prisma.service";
+
+@Module({
+    providers: [PrismaService, UserRepository],
+    exports: [PrismaService, UserRepository]
+})
+export class PrismaModule {}

--- a/backend/src/db/repositories/user.repository.ts
+++ b/backend/src/db/repositories/user.repository.ts
@@ -4,8 +4,15 @@ import { PrismaService } from '../prisma.service';
 
 @Injectable()
 export class UserRepository {
+  
   constructor(private prisma: PrismaService) {}
 
+  /**
+   * Returns a user via it's email adresss
+   * 
+   * @param email 
+   * @returns 
+   */
   public async findByEmail(email: string): Promise<User | null> {
     return await this.prisma.user.findUnique({
       where: {
@@ -14,6 +21,14 @@ export class UserRepository {
     });
   }
 
+  /**
+   * Creates a new user
+   * 
+   * @param email Valid mail address, must be unique
+   * @param displayName Display Name choosen by the user
+   * @param password Hashed Password
+   * @returns User
+   */
   public async createUser(
     email: string,
     displayName: string,
@@ -28,6 +43,12 @@ export class UserRepository {
     });
   }
 
+  /**
+   * Updates a user
+   * 
+   * @param user 
+   * @returns Updated User
+   */
   public async updateUser(user: User): Promise<User> {
     return await this.prisma.user.update({
       where: {
@@ -37,6 +58,12 @@ export class UserRepository {
     });
   }
 
+  /**
+   * Deletes a user
+   * 
+   * @param where 
+   * @returns Deleted User
+   */
   public async deleteUser(where: Prisma.UserWhereUniqueInput): Promise<User> {
     return await this.prisma.user.delete({
       where,


### PR DESCRIPTION
This PR adds authentication with the example user via Basic Auth, using the passport module.
This is implemented for early testing. When using this module, all protected endpoints must be called with valid credentials, otherwise the server will respond with 401.

The currently logged in user will be available via "req.user" in the respective controllers.

This closes #94.