### PR TITLE
Adjust API path

### DIFF
--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -4,7 +4,7 @@ import { AutoGuard } from '../../auth/auto.guard';
 
 type SanatizedUser = Omit<User, 'password'>;
 
-@Controller('user')
+@Controller('users')
 export class UserController {
   _sanatizeUser(user: User): SanatizedUser {
     const sanatizedUser: SanatizedUser & { password?: string } = user;
@@ -16,7 +16,7 @@ export class UserController {
   /**
    * /user/me
    *
-   * Returns information about the current user
+   * Returns information about the current User
    *
    * @param req
    * @returns


### PR DESCRIPTION
According to our API specification we are using the plural for resources ("/users/" instead of "/user"), this PR updates the path (and also is used to test modifications to the not working github action.