### PR TITLE
Allow users to change their email, displayName and password

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -53,3 +53,4 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Prisma
 *.sqlite
+*.sqlite-journal

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,8 @@
         "@prisma/client": "^5.11.0",
         "@types/bcrypt": "^5.0.2",
         "bcrypt": "^5.1.1",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
         "passport": "^0.7.0",
         "passport-http": "^0.3.0",
         "reflect-metadata": "^0.2.0",
@@ -2425,6 +2427,11 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.11.9",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
+      "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
@@ -3552,6 +3559,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.10.53",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -6463,6 +6485,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.61",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.61.tgz",
+      "integrity": "sha512-TsQsyzDttDvvzWNkbp/i0fVbzTGJIG0mUu/uNalIaRQEYeJxVQ/FPg+EJgSqfSXezREjM0V3RZ8cLVsKYhhw0Q=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -8960,6 +8987,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,8 @@
     "@prisma/client": "^5.11.0",
     "@types/bcrypt": "^5.0.2",
     "bcrypt": "^5.1.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "passport": "^0.7.0",
     "passport-http": "^0.3.0",
     "reflect-metadata": "^0.2.0",

--- a/backend/src/api/user/patch.user.dto.ts
+++ b/backend/src/api/user/patch.user.dto.ts
@@ -1,9 +1,15 @@
-import { IsEmail, Length } from 'class-validator';
+import { IsEmail, IsOptional, Length } from 'class-validator';
 
-export class PathUserDTO {
+export class PatchUserDTO {
   @IsEmail()
+  @IsOptional()
   email: string | undefined;
 
   @Length(12, 72)
+  @IsOptional()
   password: string | undefined;
+
+  @Length(2, 128)
+  @IsOptional()
+  displayName: string | undefined;
 }

--- a/backend/src/api/user/patch.user.dto.ts
+++ b/backend/src/api/user/patch.user.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, Length } from 'class-validator';
+
+export class PathUserDTO {
+  @IsEmail()
+  email: string | undefined;
+
+  @Length(12, 72)
+  password: string | undefined;
+}

--- a/backend/src/api/user/user.controller.spec.ts
+++ b/backend/src/api/user/user.controller.spec.ts
@@ -1,16 +1,31 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
-import { User } from '@prisma/client';
+import { Prisma, User } from '@prisma/client';
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended';
+import { UserRepository } from '../../db/repositories/user.repository';
+import { AuthService } from '../../auth/auth.service';
+import { TestConstants } from '../../../test/lib/constants';
+import { NestRequest } from '../../types/request.type';
+import { PrismaModule } from '../../db/prisma.module';
+import { Response } from 'express';
+import { PatchUserDTO } from './patch.user.dto';
 
 describe('UserController', () => {
   let controller: UserController;
+  let repository: DeepMockProxy<UserRepository>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [PrismaModule],
       controllers: [UserController],
-    }).compile();
+      providers: [UserRepository, AuthService],
+    })
+      .overrideProvider(UserRepository)
+      .useValue(mockDeep<UserRepository>())
+      .compile();
 
     controller = module.get<UserController>(UserController);
+    repository = module.get(UserRepository);
   });
 
   it('should be defined', () => {
@@ -31,8 +46,59 @@ describe('UserController', () => {
       user,
     };
 
-    const response = (await controller.me(req)) as any;
+    const response = (await controller.getMe(req)) as any;
 
     expect(response?.password).toBeUndefined();
+  });
+
+  it('should be able to change information about a user', async () => {
+    repository.updateUser.mockResolvedValue(
+      TestConstants.database.users.exampleUser,
+    );
+
+    const changeQuery: Prisma.UserUpdateInput = {
+      displayName: 'Test 1',
+      email: 'test1@example.org',
+      password: 'TEST123',
+    };
+
+    const mockRequest = {
+      user: {
+        id: TestConstants.database.users.exampleUser.id,
+      },
+    } as NestRequest;
+
+    const mockResponse = mockDeep<Response>();
+    mockResponse.status.mockReturnThis();
+
+    await controller.patchMe(
+      mockRequest,
+      {
+        displayName: changeQuery.displayName as string,
+        email: changeQuery.email as string,
+        password: changeQuery.password as string,
+      },
+      mockResponse as any,
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(200);
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      TestConstants.database.users.exampleUser,
+    );
+  });
+
+  it('should not be able to modify a user with an empty modify request', async () => {
+    const mockRequest = mockDeep<NestRequest>();
+    const mockResponse = mockDeep<Response>();
+
+    mockResponse.status.mockReturnThis();
+
+    await controller.patchMe(
+      mockRequest as NestRequest,
+      {} as PatchUserDTO,
+      mockResponse as Response,
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
   });
 });

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -1,11 +1,28 @@
-import { Controller, Get, Request, UseGuards } from '@nestjs/common';
-import { User } from '@prisma/client';
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { Prisma, User } from '@prisma/client';
 import { AutoGuard } from '../../auth/auto.guard';
+import { PathUserDTO } from './patch.user.dto';
+import { AuthService } from 'src/auth/auth.service';
+import { Response } from 'express';
+import { UserRepository } from 'src/db/repositories/user.repository';
 
 type SanatizedUser = Omit<User, 'password'>;
 
 @Controller('user')
 export class UserController {
+  constructor(
+    private authService: AuthService,
+    private userRepository: UserRepository,
+  ) {}
+
   _sanatizeUser(user: User): SanatizedUser {
     const sanatizedUser: SanatizedUser & { password?: string } = user;
 
@@ -23,7 +40,44 @@ export class UserController {
    */
   @Get('/me')
   @UseGuards(AutoGuard)
-  async me(@Request() req) {
+  async getMe(@Req() req) {
     return this._sanatizeUser(req.user);
+  }
+
+  @Patch('/me')
+  @UseGuards(AutoGuard)
+  async patchMe(
+    @Req() req: Request & { user: { id: string } },
+    @Body() userPatch: PathUserDTO,
+    @Res() res: Response,
+  ) {
+    const userChanges: Prisma.UserUpdateInput = {};
+
+    if (userPatch.password) {
+      const hashedPassword = await this.authService.hashPassword(
+        userPatch.password,
+      );
+
+      userChanges.password = hashedPassword;
+    }
+
+    if (userPatch.email) {
+      userChanges.email = userPatch.email;
+      userChanges.verified = false;
+    }
+
+    if (Object.keys(userChanges).length > 0) {
+      const user = await this.userRepository.updateUser(
+        req.user.id,
+        userChanges,
+      );
+
+      return user;
+    } else {
+      res.statusCode = 400;
+      return {
+        error: 'Nothing was changed',
+      };
+    }
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,9 +3,10 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { UserController } from './api/user/user.controller';
+import { PrismaModule } from './db/prisma.module';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, PrismaModule],
   controllers: [AppController, UserController],
   providers: [AppService],
 })

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,5 +8,6 @@ import { AutoGuard } from './auto.guard';
 @Module({
   imports: [PrismaModule, PassportModule],
   providers: [AuthService, HTTPStrategy, AutoGuard],
+  exports: [AuthService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -27,4 +27,14 @@ export class AuthService {
 
     return null;
   }
+
+  /**
+   * Hashes a password using the preferred hash algorithm.
+   * @param password Plaintext password
+   * @returns Hashe password
+   */
+  async hashPassword(password: string): Promise<string> {
+    return await bcrypt.hash(password, 12);
+  }
+
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -36,5 +36,4 @@ export class AuthService {
   async hashPassword(password: string): Promise<string> {
     return await bcrypt.hash(password, 12);
   }
-
 }

--- a/backend/src/db/repositories/user.repository.spec.ts
+++ b/backend/src/db/repositories/user.repository.spec.ts
@@ -57,7 +57,7 @@ describe('UserRepository tests', () => {
   it('should be able to modify a user', async () => {
     prisma.user.update.mockResolvedValue(exampleUser);
 
-    const user = await userRepository.updateUser(exampleUser);
+    const user = await userRepository.updateUser(exampleUser.id, exampleUser);
     expect(user).toEqual(exampleUser);
   });
 });

--- a/backend/src/db/repositories/user.repository.ts
+++ b/backend/src/db/repositories/user.repository.ts
@@ -48,12 +48,15 @@ export class UserRepository {
    * @param user
    * @returns Updated User
    */
-  public async updateUser(user: User): Promise<User> {
+  public async updateUser(
+    id: string,
+    update: Prisma.UserUpdateInput,
+  ): Promise<User> {
     return await this.prisma.user.update({
       where: {
-        id: user.id,
+        id: id,
       },
-      data: user,
+      data: update,
     });
   }
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe());
   await app.listen(3000);
 }
 

--- a/backend/src/types/request.type.ts
+++ b/backend/src/types/request.type.ts
@@ -1,0 +1,5 @@
+import { Request } from 'express';
+
+export type NestRequest = Request & {
+  user: { id: string };
+};

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,6 +10,7 @@ export default withMermaid({
       { text: 'Home', link: '/' },
       { text: 'Projekt', link: '/project/idea' },
       { text: 'Guidelines', link: '/guidelines/project-guideline' },
+      { text: 'Development', link: '/development/overview',  }
     ],
 
     sidebar: {
@@ -34,6 +35,9 @@ export default withMermaid({
             { text: 'Frontend Guideline', link: '/guidelines/frontend' }
           ]
         }
+      ],
+      '/development': [
+        { text: 'Authentication', link: '/development/authentication' }
       ]
     },
 

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -1,0 +1,13 @@
+# Authentication
+> [!WARNING]
+> The currently used authentication mechanism is subject to changes and only intended for development purposes.
+## Local Authentication (Development)
+During development `Basic`-Authentication is enabled to make authentication easier. You need to supply a username and a password.
+There are example users available, when using the database seeds.
+
+### Example Users
+The password for all available example users is
+`1234`.
+Please note that those users are not available in production.
+
+- `max@example.org`: Max Mustermann

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -1,0 +1,3 @@
+# Development
+> [!WARNING]
+> This section is subject to change as it's intended to document the development process. This is not intented for an external audience.


### PR DESCRIPTION
This PR introduces the `PATCH /user/me` endpoint.
It also includes a (limited) documentation for the authentication process in development, which is being added to the wiki.

This closes #132.