### PR TITLE
.env.example file

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=file:./database.dev.sqlite


### PR DESCRIPTION
Added an example .env file. This currently only includes the `DATABASE_URL` parameter. Without it, the backend can not be started. 