### PR TITLE
Add Docker image for backend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,59 @@
+# compiled output
+/dist
+/node_modules
+/build
+
+# Logs
+logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# temp directory
+.temp
+.tmp
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Prisma
+*.sqlite
+
+# Docker
+Dockerfile
+.dockerignore

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20
+
+USER node
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY --chown=node:node . .
+
+RUN npm run build
+
+CMD [ "node", "dist/main.js" ]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,11 +5,15 @@ USER node
 WORKDIR /usr/src/app
 
 COPY package*.json ./
+COPY prisma ./prisma/
 
 RUN npm ci
 
 COPY --chown=node:node . .
 
+ENV NODE_ENV production
+
 RUN npm run build
 
-CMD [ "node", "dist/main.js" ]
+EXPOSE 3000
+CMD [ "npm", "start", "prod" ]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,4 +16,4 @@ ENV NODE_ENV production
 RUN npm run build
 
 EXPOSE 3000
-CMD [ "npm", "start", "prod" ]
+CMD [ "npm", "run", "start:prod" ]

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "verify": "npm run build && npm run check && npm run test:cov && npm run test:e2e",
-    "build": "nest build",
+    "build": "prisma generate && nest build",
     "start": "nest start",
     "start:dev": "npm run db:reset && nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -6,7 +6,7 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider = "sqlite"
   url      = env("DATABASE_URL")
 }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -5,8 +5,8 @@ generator client {
   provider = "prisma-client-js"
 }
 
-datasource db {
-  provider = "sqlite"
+datasource development {
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator client {
   provider = "prisma-client-js"
 }
 
-datasource development {
+datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,25 +4,26 @@ services:
     ports:
       - "8080:3000"
     environment:
-      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-development_only}@postgres:5432/duogradus?schema=public"
+      # DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-development_only}@postgres:5432/duogradus?schema=public"
+      DATABASE_URL: "file:./database.dev.sqlite"
     networks:
       - backend
-  postgres:
-    image: postgres
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-development_only}
-      POSTGRES_DB: duogradus
-      PGDATA: /data/postgres
-    volumes:
-      - postgres:/data/postgres
-    networks:
-      - backend
-    restart: always
+  # postgres:
+  #   image: postgres
+  #   environment:
+  #     POSTGRES_USER: ${POSTGRES_USER:-postgres}
+  #     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-development_only}
+  #     POSTGRES_DB: duogradus
+  #     PGDATA: /data/postgres
+  #   volumes:
+  #     - postgres:/data/postgres
+  #   networks:
+  #     - backend
+  #   restart: always
 
 
-networks:
-  backend:
+# networks:
+#   backend:
 
-volumes:
-  postgres:
+# volumes:
+#   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
       DATABASE_URL: "file:./database.dev.sqlite"
     networks:
       - backend
+  webserver:
+    build: ./frontend
+    ports:
+      - "8000:8000"
+    networks:
+      - backend
   # postgres:
   #   image: postgres
   #   environment:
@@ -22,8 +28,8 @@ services:
   #   restart: always
 
 
-# networks:
-#   backend:
+networks:
+   backend:
 
 # volumes:
 #   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8080:3000"
+    environment:
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-development_only}@postgres:5432/duogradus?schema=public"
+    networks:
+      - backend
+  postgres:
+    image: postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-development_only}
+      POSTGRES_DB: duogradus
+      PGDATA: /data/postgres
+    volumes:
+      - postgres:/data/postgres
+    networks:
+      - backend
+    restart: always
+
+
+networks:
+  backend:
+
+volumes:
+  postgres:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -50,6 +50,7 @@ export default withMermaid({
       '/development': [
         { text: 'Project Guideline', link: '/development/project-guideline' },
         { text: 'API', link: '/development/api' },
+        { text: 'Deployment', link: '/development/deployment' },
         {
           text: 'Backend',
           link: '/development/backend/overview',

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -4,7 +4,7 @@ Ziel ist es, die Anwendung während der Entwicklung auf einem Test-Server laufen
 Um dies zu erreichen gibt es im Backend ein `Dockerfile`, welches spezifische Build Anweisungen vorgibt. Dadurch wird ein Dockerimage für das Backend erstellt.
 Mithilfe der `docker-compose.yml` im Wurzelverzeichnis der Anwendung kann das ganze Projekt gestartet werden.
 
-Nach dem starten der Container kann die Anwendung über `localhost:8000` aufgerufen werden. Die API wird über den Reverse-Proxy mit `/api/` bereitgestellt. Das Frontend direkt über `/`
+Nach dem starten der Container kann die Anwendung über http://localhost:8000 aufgerufen werden. Die API wird über den Reverse-Proxy mit `/api/` bereitgestellt. Das Frontend direkt über `/`
 
 **Befehl zum starten der Anwendung**:
 

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -1,8 +1,8 @@
 # Deployment
 
-Ziel ist es, die Anwendung während der Entwicklung auf einem Test-Server laufen zu lassen. Um die Aufgabe zu vereinfachen, soll die Anwendung mittels "Docker" gestartet werden können.
-Um dies zu erreichen gibt es im Backend ein "Dockerfile", welches spezifische Build Anweisungen vorgibt. Dadurch wird ein Dockerimage für das Backend erstellt.
-Mithilfe der "docker-compose.yml" im Wurzelverzeichnis der Anwendung kann das ganze Projekt gestartet werden.
+Ziel ist es, die Anwendung während der Entwicklung auf einem Test-Server laufen zu lassen. Um die Aufgabe zu vereinfachen, soll die Anwendung mittels [Docker](https://docs.docker.com/get-started/overview/) gestartet werden können.
+Um dies zu erreichen gibt es im Backend ein `Dockerfile`, welches spezifische Build Anweisungen vorgibt. Dadurch wird ein Dockerimage für das Backend erstellt.
+Mithilfe der `docker-compose.yml` im Wurzelverzeichnis der Anwendung kann das ganze Projekt gestartet werden.
 
 Nach dem starten der Container kann die Anwendung über `localhost:8000` aufgerufen werden. Die API wird über den Reverse-Proxy mit `/api/` bereitgestellt. Das Frontend direkt über `/`
 

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -1,0 +1,28 @@
+# Deployment
+
+Ziel ist es, die Anwendung während der Entwicklung auf einem Test-Server laufen zu lassen. Um die Aufgabe zu vereinfachen, soll die Anwendung mittels "Docker" gestartet werden können.
+Um dies zu erreichen gibt es im Backend ein "Dockerfile", welches spezifische Build Anweisungen vorgibt. Dadurch wird ein Dockerimage für das Backend erstellt.
+Mithilfe der "docker-compose.yml" im Wurzelverzeichnis der Anwendung kann das ganze Projekt gestartet werden.
+
+**Befehl zum starten der Anwendung**:
+```bash
+docker compose up -d
+```
+
+**Befehl zum "Neubauen" der Anwendung (bei Änderungen des Codes)**:
+```bash
+docker compose build
+```
+
+**Anwendung stoppen**:
+```bash
+docker compose down
+```
+
+**Nutzdaten löschen**:
+```bash
+docker compose rm
+```
+
+> [!NOTE]
+> Es existiert zudem der Befehl "docker-compose", welcher ähnlich bedient werden kann. Jedoch ist dieser Befehl deprecated und sollte nicht mehr genutzt werden!

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -4,6 +4,8 @@ Ziel ist es, die Anwendung während der Entwicklung auf einem Test-Server laufen
 Um dies zu erreichen gibt es im Backend ein "Dockerfile", welches spezifische Build Anweisungen vorgibt. Dadurch wird ein Dockerimage für das Backend erstellt.
 Mithilfe der "docker-compose.yml" im Wurzelverzeichnis der Anwendung kann das ganze Projekt gestartet werden.
 
+Nach dem starten der Container kann die Anwendung über `localhost:8000` aufgerufen werden. Die API wird über den Reverse-Proxy mit `/api/` bereitgestellt. Das Frontend direkt über `/`
+
 **Befehl zum starten der Anwendung**:
 
 ```bash

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -5,21 +5,25 @@ Um dies zu erreichen gibt es im Backend ein "Dockerfile", welches spezifische Bu
 Mithilfe der "docker-compose.yml" im Wurzelverzeichnis der Anwendung kann das ganze Projekt gestartet werden.
 
 **Befehl zum starten der Anwendung**:
+
 ```bash
 docker compose up -d
 ```
 
 **Befehl zum "Neubauen" der Anwendung (bei Änderungen des Codes)**:
+
 ```bash
 docker compose build
 ```
 
 **Anwendung stoppen**:
+
 ```bash
 docker compose down
 ```
 
 **Nutzdaten löschen**:
+
 ```bash
 docker compose rm
 ```

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist/
+.env
+.env*

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -1,0 +1,12 @@
+:8000 {
+    route {
+        handle_path /api/* {
+            reverse_proxy http://backend:3000
+        }
+
+        root * /usr/dist
+        encode gzip
+        try_files {path} /index.html
+        file_server
+    }
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+# Build the frontend
+FROM node:20 as build
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN npm ci
+# Actual building
+RUN npm run build
+
+# Server image
+FROM caddy as server
+COPY Caddyfile /etc/caddy/Caddyfile
+COPY --from=build /usr/src/app/dist/frontend/browser /usr/dist
+
+EXPOSE 8000

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -105,5 +105,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }


### PR DESCRIPTION
As requested in #98 this PR adds a docker image for the backend, and a `docker-compose.yml` which can be used to start the application with postgres and a reverse proxy which both servers the frontend application and the backend application.