### PR TITLE
Fix deployment.md

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Run check format
         run: cd docs && npm run check:format
+
+      - name: Run build
+        run: cd docs && npm run docs:build

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -4,7 +4,7 @@ Ziel ist es, die Anwendung während der Entwicklung auf einem Test-Server laufen
 Um dies zu erreichen gibt es im Backend ein `Dockerfile`, welches spezifische Build Anweisungen vorgibt. Dadurch wird ein Dockerimage für das Backend erstellt.
 Mithilfe der `docker-compose.yml` im Wurzelverzeichnis der Anwendung kann das ganze Projekt gestartet werden.
 
-Nach dem starten der Container kann die Anwendung über http://localhost:8000 aufgerufen werden. Die API wird über den Reverse-Proxy mit `/api/` bereitgestellt. Das Frontend direkt über `/`
+Nach dem starten der Container kann die Anwendung über <http://localhost:8000> aufgerufen werden. Die API wird über den Reverse-Proxy mit `/api/` bereitgestellt. Das Frontend direkt über `/`
 
 **Befehl zum starten der Anwendung**:
 

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -4,7 +4,7 @@ Ziel ist es, die Anwendung während der Entwicklung auf einem Test-Server laufen
 Um dies zu erreichen gibt es im Backend ein `Dockerfile`, welches spezifische Build Anweisungen vorgibt. Dadurch wird ein Dockerimage für das Backend erstellt.
 Mithilfe der `docker-compose.yml` im Wurzelverzeichnis der Anwendung kann das ganze Projekt gestartet werden.
 
-Nach dem starten der Container kann die Anwendung über <http://localhost:8000> aufgerufen werden. Die API wird über den Reverse-Proxy mit `/api/` bereitgestellt. Das Frontend direkt über `/`
+Nach dem starten der Container kann die Anwendung über <a href="http://localhost:8000" target="_blank" rel="noreferrer noopener">localhost:8000</a> aufgerufen werden. Die API wird über den Reverse-Proxy mit `/api/` bereitgestellt. Das Frontend direkt über `/`
 
 **Befehl zum starten der Anwendung**:
 


### PR DESCRIPTION
As discussed. According to https://github.com/vuejs/vitepress/issues/822, the current workaround seems to be `<a href="http://localhost:8000" target="_blank" rel="noreferrer noopener">localhost:8000</a>`