### PR TITLE
Auto deployment: Simple action

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,0 +1,19 @@
+name: Deploy application to staging environment
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: [self-hosted]
+    steps:
+      - name: Execute the build and run script on the server
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script: "/services/duogradus/build-and-run.sh"

--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -1,8 +1,10 @@
-# Download the current code main branch from github
-git pull
-
 # Stop the current docker compose server
 docker compose down
+
+# Download the current code main branch from github
+git fetch --all
+# Yes, this is the desired option!
+git reset --hard origin/master
 
 # Rebuild the images with the new code
 docker compose build

--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -1,0 +1,11 @@
+# Download the current code main branch from github
+git pull
+
+# Stop the current docker compose server
+docker compose down
+
+# Rebuild the images with the new code
+docker compose build
+
+# Restart the service
+docker compose up -d


### PR DESCRIPTION
This adds a simple action to trigger the autodeployment of our application to the staging environment.
To keep this clean, the building of the application hapens in the staging environment.

We could further improve this by using GitHub packages or similar technology and build the packages directly on github, but I think for now this is suitable.