### PR TITLE
Fixed `docs` mockup links

### DIFF
--- a/docs/project/user-interface.md
+++ b/docs/project/user-interface.md
@@ -2,10 +2,29 @@
 
 Folgende Vorschläge für die Benutzeroberfläche gibt es.
 
-[Homepage](/mockups/Homepage.pdf)\
-[Ranking Page](/mockups/mockups/Ranking.pdf)\
-[Account Page](/mockups/mockups/Account.pdf)\
-[Friendlist Page](/mockups/mockups/Friendlist.pdf)\
-[Settings Page](/mockups/mockups/Settings.pdf)
+## Login Seite
+
+![Login Seite](/mockups/Loginpage.pdf)
+
+## Homepage
+
+![Mainpage_1](/mockups/Mainpage_1.pdf)
+
+### Homepage mit Training
+
+![Mainpage_2](/mockups/Mainpage_2.pdf)
+
+## Ranking Seite
+
+![Ranking Seite](/mockups/Rankingpage.pdf)
+
+## Profil Seite
+
+![Profile Seite](/mockups/Profilepage.pdf)
+
+## Freunde Seite
+
+![Friend Seite](/mockups/Friendpage.pdf)
+![Add friend Seite](/mockups/Add_Friendpage.pdf)
 
 Die Designvorschläge werden über Figma erstellt und befinden sich in diesem Projekt: ([Zu Figma](https://www.figma.com/file/l2Lz3Kdxe8IPPcDEplvrsv/DuoGradus?type=design&node-id=0-1&mode=design&t=r3O0jl2pgqHURD05-0))


### PR DESCRIPTION
This PR fixes the dead links in [`docs.duo-gradus.de/project/user-interface`](https://docs.duo-gradus.de/project/user-interface.html) to the mockups. The PR belongs to #188.