### PR TITLE
Disable coverage on verify

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "verify": "npm run build && npm run check && npm run test:cov && npm run test:e2e",
+    "verify": "npm run build && npm run check && npm run test && npm run test:e2e",
     "build": "prisma generate && nest build",
     "start": "nest start",
     "start:dev": "npm run db:reset && nest start --watch",
@@ -80,13 +80,6 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
-    "coverageThreshold": {
-      "global": {
-        "lines": 90,
-        "functions": 80,
-        "branches": 80
-      }
-    },
     "coveragePathIgnorePatterns": [
       "src/db/prisma.seed.ts",
       "main.ts"


### PR DESCRIPTION
This PR disables the coverage checks as described in #203. 
The existing unit tests will still run, but the coverage is no criteria anymore the action.

This closes #203.